### PR TITLE
Added Stats and Leveling

### DIFF
--- a/Assets/Character/Player Attack/BaseAttack.cs
+++ b/Assets/Character/Player Attack/BaseAttack.cs
@@ -32,12 +32,8 @@ public class BaseAttack : MonoBehaviour
     {
         if (Input.GetButtonDown("Attack"))
         {
-            
-     
             anim.SetTrigger("Attack");
             StartCoroutine(StartAttack());
-
-        
         }
     }
 
@@ -60,7 +56,7 @@ public class BaseAttack : MonoBehaviour
     {
         if (other.gameObject.CompareTag("Enemy"))
         { 
-        other.GetComponent<Monster>().TakeDamage(damage);
+            other.GetComponent<Monster>().TakeDamage(damage);
         }
     }
 

--- a/Assets/Character/Stats_Level.meta
+++ b/Assets/Character/Stats_Level.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9c6ee42b9e200124ba4de40186691eee
+guid: 8e0238ea313f5894fbf2c735e177f894
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Character/Stats_Level/ExpManager.cs
+++ b/Assets/Character/Stats_Level/ExpManager.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ExpManager : MonoBehaviour
+{
+    public static ExpManager Instance;
+    public delegate void ExpRewardDelegator(int expAmount);
+    public event ExpRewardDelegator OnReward;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(this);
+        }
+        else
+        {
+            Instance = this;
+        }
+    }
+
+    //When ExpRewardDelegator is called, upon reward give exp amount.
+    public void GiveExp(int expAmount)
+    {
+        OnReward?.Invoke(expAmount);
+    }
+}

--- a/Assets/Character/Stats_Level/ExpManager.cs.meta
+++ b/Assets/Character/Stats_Level/ExpManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58ed6a783717f7549a5007a05cff837a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Character/Stats_Level/Stats_Level.cs
+++ b/Assets/Character/Stats_Level/Stats_Level.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+public class Stats_Level : MonoBehaviour
+{
+    [SerializeField] public int level = 1;
+    [SerializeField] public int currentExp = 0;
+    [SerializeField] public int requiredExp = 100;
+    [SerializeField] public int health = 100;
+    [SerializeField] public int attack = 1;
+    [SerializeField] public int defense = 0;
+    [SerializeField] public int strength = 1;
+    [SerializeField] public int dexterity = 1;
+
+    private void OnEnable()
+    {
+        ExpManager.Instance.OnReward += ExpCheck;
+    }
+    private void OnDisable()
+    {
+        ExpManager.Instance.OnReward -= ExpCheck;
+    }
+
+    private void ExpCheck(int expReward)
+    {
+        currentExp += expReward;
+        while (currentExp >= requiredExp)
+        {
+            LevelUp();
+        }
+    }
+
+    private void LevelUp()
+    {
+        level += 1;
+        health += 50;
+        attack += 1;
+        defense += 1;
+        strength += 1;
+        dexterity += 1;
+
+        currentExp -= requiredExp;
+        requiredExp += requiredExp + ((int)Math.Pow(level, 4)/4);
+    }
+}

--- a/Assets/Character/Stats_Level/Stats_Level.cs.meta
+++ b/Assets/Character/Stats_Level/Stats_Level.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7f6a525f4f6b1e4d82605e562a50c8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Monsters/Enemy Script/Bat.cs
+++ b/Assets/Monsters/Enemy Script/Bat.cs
@@ -7,18 +7,16 @@ public class Bat : Monster
 
 
     // Start is called before the first frame update
-   public void Start()
+   public new void Start()
     {
         base.Start();
+        health = 5;
+        expReward = 1000;
     }
 
     // Update is called once per frame
-    public void Update()
+    public new void Update()
     {
         base.Update();
     }
-
-
- 
-
 }

--- a/Assets/Monsters/Enemy Script/Monster.cs
+++ b/Assets/Monsters/Enemy Script/Monster.cs
@@ -5,49 +5,51 @@ using UnityEngine;
 public abstract  class Monster : MonoBehaviour
 {
     [SerializeField] public int health;
-    [SerializeField] public int damage;
+    [SerializeField] public int ReceivedDamage;
     [SerializeField] public float flashtime;
+    [SerializeField] public int expReward;
     
-
-    //flash when by hit
-    private SpriteRenderer sr;
-    private Color originlColor;
+    private SpriteRenderer monsterSprite;
+    private Color originalColor;
 
 
     // Start is called before the first frame update
     public void Start()
     {
-        sr = GetComponent<SpriteRenderer>();
-        originlColor = sr.color;
+        monsterSprite = GetComponent<SpriteRenderer>();
+        originalColor = monsterSprite.color;
     }
 
     // Update is called once per frame
    public void Update()
     {
         if (health <= 0)
-        { 
-        Destroy(gameObject);
+        {
+            Die();
         }
     }
-    public void TakeDamage(int damage)
+    public void TakeDamage(int ReceivedDamage)
     { 
         
-        health -= damage;
+        health -= ReceivedDamage;
         FlashColor(flashtime);
     }
 
 
     void FlashColor(float time)
     {
-        sr.color = Color.red;
+        monsterSprite.color = Color.red;
         Invoke("ResetColor", time);
     }
 
-    private void ResetColor()
+    void ResetColor()
     {
-        sr.color = originlColor;
-
+        monsterSprite.color = originalColor;
     }
 
-
+    void Die()
+    {
+        ExpManager.Instance.GiveExp(expReward);
+        Destroy(gameObject);
+    }
 }

--- a/Assets/Scenes/Map1.unity
+++ b/Assets/Scenes/Map1.unity
@@ -792,9 +792,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95394ac62d097f046b1b9af51b8fe794, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  health: 10
-  damage: 3
+  health: 5
+  ReceivedDamage: 0
   flashtime: 0.2
+  expReward: 1000
 --- !u!61 &358490437
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -964,6 +965,50 @@ Transform:
   - {fileID: 1640058134}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &417114104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 417114106}
+  - component: {fileID: 417114105}
+  m_Layer: 0
+  m_Name: ExpManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &417114105
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417114104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58ed6a783717f7549a5007a05cff837a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &417114106
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417114104}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.31892085, y: -0.08901798, z: 0.034193344}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -1116,6 +1161,7 @@ GameObject:
   - component: {fileID: 618832042}
   - component: {fileID: 618832043}
   - component: {fileID: 618832044}
+  - component: {fileID: 618832045}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -1329,6 +1375,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d47f30da5bb9a54eaddfc84c83ef8b2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &618832045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 618832037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f7f6a525f4f6b1e4d82605e562a50c8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  health: 100
+  attack: 1
+  defence: 0
+  strength: 1
+  dexterity: 1
+  currentLevel: 1
+  currentExp: 0
+  requiredExp: 100
 --- !u!1 &619394800
 GameObject:
   m_ObjectHideFlags: 0
@@ -5017,3 +5083,4 @@ SceneRoots:
   - {fileID: 134642708}
   - {fileID: 685441119}
   - {fileID: 237810198}
+  - {fileID: 417114106}


### PR DESCRIPTION
By using a delegate to create an event to be Invoke'd inside Monster abstract class when monsters die, which enables the expcheck in Player's Stats_Level script to level up.

For the time being, the stats I've implemented are Health, Attack, Defense, and Dexterity. Dexterity can be used to work with jump and movement speed in the future. As the player gain levels, they move faster and jump higher. In my opinion no more than twice the amount at level 1. No cap has been placed for the player's level.
No cap has been placed for each stats.

No Known Bug.